### PR TITLE
Flag Just, Maybe, Stuff and Things as vague constructs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # Adverb Where?
 
-npm module for checking for adverbs. Adverbs can have the effect of being an [intensifier that doesn't intensify](http://grammar.ccc.commnet.edu/grammar/concise.htm#intensifiers).
+npm module for checking for adverbs or vague constructs. Adverbs can have the
+effect of being an [intensifier that doesn't
+intensify](http://grammar.ccc.commnet.edu/grammar/concise.htm#intensifiers).
 
 ## Install
 

--- a/adverbs.js
+++ b/adverbs.js
@@ -201,7 +201,17 @@ var adverbs = [
   'yearl'
 ];
 
-var adverbRegex = new RegExp('\\b(' + adverbs.join('|') + ')(y)\\b', 'gi');
+var weakens = [
+  'just',
+  'maybe',
+  'stuff',
+  'things'
+];
+
+var adverbRegex = new RegExp(
+  '\\b(' +
+  '(' + adverbs.join('|') + ')(y)' +
+  '|(' + weakens.join('|') + '))\\b', 'gi');
 var matcher = require("./matcher");
 
 module.exports = function (text) {

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -1,6 +1,7 @@
 var adverbs = require('../adverbs');
 var badWordInSentence = 'Allegedly, this sentence is terrible.';
 var goodSentence = 'The good dog jumps over the bad cat.';
+var vagueSentence = 'We are writing about things and stuff.';
 
 describe('adverb-where', function () {
 
@@ -18,5 +19,10 @@ describe('adverb-where', function () {
 
   it('should not have a problem with a short sentence', function () {
     expect(adverbs(goodSentence)).toEqual([]);
+  });
+
+  it('should flag vague constructs', function () {
+    expect(adverbs(vagueSentence)).toEqual(
+           [{index: 21, offset: 6 }, {index: 32, offset: 5 }]);
   });
 });


### PR DESCRIPTION
Hey Matt,

I'm trying to integrated the advice from http://mashable.com/2015/05/03/words-eliminate-vocabulary to write-good and friends.

I think that adverb-where is in this case the closest module, as the diagnostic from write-good would be '"maybe|just|stuff|things" can weaken meaning', even if stuff & things aren't, well, adverbs.

One other approach would be to create, another module just for 'stuff' and 'things' and keep only maybe/just here. That sounds a bit more complicated, so I went for the first/simpler approach. But I'm happy to iterate if you have something else to suggest.

Thanks!
