### PR TITLE
Remove time adjectives

### DIFF
--- a/adverbs.js
+++ b/adverbs.js
@@ -36,7 +36,6 @@ var adverbs = [
   'crumbl',
   'cuddl',
   'currentl',
-  'dail',
   'daringl',
   'deadl',
   'definitel',
@@ -108,13 +107,11 @@ var adverbs = [
   'man',
   'mentall',
   'mildl',
-  'monthl',
   'mortall',
   'mostl',
   'mysteriousl',
   'neatl',
   'nervousl',
-  'nightl',
   'noisil',
   'normall',
   'obedientl',
@@ -194,12 +191,10 @@ var adverbs = [
   'waverl',
   'weakl',
   'wearil',
-  'weekl',
   'wildl',
   'wisel',
   'worldl',
-  'wrinkl',
-  'yearl'
+  'wrinkl'
 ];
 
 var weakens = [


### PR DESCRIPTION
`weekly, monthly, yearly, daily` are adjectives as well as adverbs, and I do not think that they lessen the force of your writing the way `very` or `really` do. I suggest we remove them. This fixes #4.